### PR TITLE
Fixing Python version and IoT GreenGrass Image

### DIFF
--- a/cdk.context.template.json
+++ b/cdk.context.template.json
@@ -1,6 +1,6 @@
 {
-  "adminEmail": "youremail@email.com",
-  "wifiSsid": "YourWifiSsidHere",
+  "adminEmail": "",
+  "wifiSsid": "AWSeuFieldDemo",
   "projectName": "EnergyKit",
   "energyCategory": "wind",
   "deployIotStack": true,
@@ -9,5 +9,6 @@
   "deploySimulatorStack": true,
   "workshopOption": false,
   "nagEnabled": false,
-  "DEPLOYMENT_ENV": "DEV"
+  "DEPLOYMENT_ENV": "DEV",
+  "awsRegion": ""
 }

--- a/lib/constructs/construct-ek-python-lambda-function/construct-ek-python-lambda-function.ts
+++ b/lib/constructs/construct-ek-python-lambda-function/construct-ek-python-lambda-function.ts
@@ -26,7 +26,7 @@ interface EkLambdaProps {
 
     /**
      * Optional: set lambda runtime to select different python runtime
-     * @default lambda.Runtime.PYTHON_3_9
+     * @default lambda.Runtime.PYTHON_3_12
      */
     readonly runtime: lambda.Runtime;
 

--- a/lib/constructs/construct-grafana-deployment-self-hosted/datasources/datasources.yaml
+++ b/lib/constructs/construct-grafana-deployment-self-hosted/datasources/datasources.yaml
@@ -8,5 +8,5 @@ datasources:
     jsonData:
       assumeRoleArn: REPLACE_WITH_DATASOURCE_ROLE_ARN
       authType: default
-      defaultRegion: us-east-1
+      defaultRegion: eu-west-1
       workspaceId: EKTwinmakerStackTwinMakerEC21B29E

--- a/lib/constructs/construct-greengrass-vending-machine-cloud-pipeline/construct-greengrass-vending-machine.ts
+++ b/lib/constructs/construct-greengrass-vending-machine-cloud-pipeline/construct-greengrass-vending-machine.ts
@@ -73,7 +73,7 @@ export class GreengrassVendingMachine extends Construct {
 
     // Lambda that configures the rpi-image-builder and stores it in the pipeline source bucket
     const configureRpiImageBuilderFunction = new lambda.Function(this, 'ConfigureRpiImageBuilderFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'app.on_event',
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda/configure_rpi_image_builder')),
       timeout: Duration.seconds(60),
@@ -92,7 +92,7 @@ export class GreengrassVendingMachine extends Construct {
 
     // Lambda that configures the rpi-image-builder and stores it in the pipeline source bucket
     const preProvisionHooksFunction = new lambda.Function(this, 'PreProvisionHooksFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'app.on_event',
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda/pre_provision_hooks')),
       timeout: Duration.seconds(60),
@@ -287,6 +287,9 @@ export class GreengrassVendingMachine extends Construct {
               // Install dependencies required by the build-rpi-image.bash script
               'apt-get update',
               'apt-get -y install p7zip-full wget libxml2-utils kpartx',
+              'wget -qO - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -',
+              'echo \"### THIS FILE IS AUTOMATICALLY CONFIGURED ###\n# You may comment out this entry, but any other modifications may be lost.\ndeb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main\" | sudo tee -a /etc/apt/sources.list.d/google-linux.list',
+              'sudo apt update'
             ],
           },
           build: {

--- a/lib/constructs/construct-greengrass-vending-machine-cloud-pipeline/rpi-image-builder-ggcd/startup-service/startup.bash
+++ b/lib/constructs/construct-greengrass-vending-machine-cloud-pipeline/rpi-image-builder-ggcd/startup-service/startup.bash
@@ -70,7 +70,7 @@ systemctl start greengrass.service
 curl -s https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zip > greengrass-nucleus-latest.zip && unzip greengrass-nucleus-latest.zip -d GreengrassCore
 
 # run installer and set up device
-sudo -E java -Droot="/greengrass/v2" -Dlog.store=FILE -jar ./GreengrassCore/lib/Greengrass.jar --aws-region us-east-1 --thing-name amazon-scs-test  --component-default-user ggc_user:ggc_group --provision true --setup-system-service true --deploy-dev-tools true
+sudo -E java -Droot="/greengrass/v2" -Dlog.store=FILE -jar ./GreengrassCore/lib/Greengrass.jar --aws-region eu-west-1 --thing-name amazon-scs-test  --component-default-user ggc_user:ggc_group --provision true --setup-system-service true --deploy-dev-tools true
 
 # reboot pi
 /sbin/shutdown -r 1 "reboot in 1 minute"

--- a/lib/constructs/construct-greengrass-vending-machine/construct-greengrass-vending-machine.ts
+++ b/lib/constructs/construct-greengrass-vending-machine/construct-greengrass-vending-machine.ts
@@ -73,7 +73,7 @@ export class GreengrassVendingMachine extends Construct {
 
     // Lambda that configures the rpi-image-builder and stores it in the pipeline source bucket
     const configureRpiImageBuilderFunction = new lambda.Function(this, 'ConfigureRpiImageBuilderFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'app.on_event',
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda/configure_rpi_image_builder')),
       timeout: Duration.seconds(60),
@@ -92,7 +92,7 @@ export class GreengrassVendingMachine extends Construct {
 
     // Lambda that configures the rpi-image-builder and stores it in the pipeline source bucket
     const preProvisionHooksFunction = new lambda.Function(this, 'PreProvisionHooksFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'app.on_event',
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda/pre_provision_hooks')),
       timeout: Duration.seconds(60),
@@ -287,6 +287,9 @@ export class GreengrassVendingMachine extends Construct {
               // Install dependencies required by the build-rpi-image.bash script
               'apt-get update',
               'apt-get -y install p7zip-full wget libxml2-utils kpartx',
+              'wget -qO - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -',
+              'echo \"### THIS FILE IS AUTOMATICALLY CONFIGURED ###\n# You may comment out this entry, but any other modifications may be lost.\ndeb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main\" | sudo tee -a /etc/apt/sources.list.d/google-linux.list',
+              'sudo apt update'
             ],
           },
           build: {

--- a/lib/constructs/construct-greengrass-vending-machine/rpi-image-builder-ggcd/startup-service/startup.bash
+++ b/lib/constructs/construct-greengrass-vending-machine/rpi-image-builder-ggcd/startup-service/startup.bash
@@ -70,7 +70,7 @@ systemctl start greengrass.service
 curl -s https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zip > greengrass-nucleus-latest.zip && unzip greengrass-nucleus-latest.zip -d GreengrassCore
 
 # run installer and set up device
-sudo -E java -Droot="/greengrass/v2" -Dlog.store=FILE -jar ./GreengrassCore/lib/Greengrass.jar --aws-region us-east-1 --thing-name amazon-scs-test  --component-default-user ggc_user:ggc_group --provision true --setup-system-service true --deploy-dev-tools true
+sudo -E java -Droot="/greengrass/v2" -Dlog.store=FILE -jar ./GreengrassCore/lib/Greengrass.jar --aws-region eu-west-1 --thing-name amazon-scs-test  --component-default-user ggc_user:ggc_group --provision true --setup-system-service true --deploy-dev-tools true
 
 # reboot pi
 /sbin/shutdown -r 1 "reboot in 1 minute"

--- a/lib/constructs/construct-iot-control-panel/construct-iot-control-panel.ts
+++ b/lib/constructs/construct-iot-control-panel/construct-iot-control-panel.ts
@@ -38,7 +38,7 @@ export class IotControlPanel extends Construct {
 
     // Lambda that configures the rpi-image-builder and stores it in the pipeline source bucket
     const simulateTurbinesAnomalyFunction = new lambda.Function(this, 'simulateTurbinesAnomalyFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'app.on_event',
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda/simulate_turbines_anomaly')),
       timeout: Duration.seconds(60),
@@ -57,7 +57,7 @@ export class IotControlPanel extends Construct {
     });
 
     const simulateTurbinesNormalFunction = new lambda.Function(this, 'simulateTurbinesNormalFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'app.on_event',
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda/simulate_turbines_normal')),
       timeout: Duration.seconds(60),
@@ -76,7 +76,7 @@ export class IotControlPanel extends Construct {
     });
 
     const stopTurbinesFunction = new lambda.Function(this, 'stopTurbinesFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'app.on_event',
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda/stop_turbines')),
       timeout: Duration.seconds(60),
@@ -95,7 +95,7 @@ export class IotControlPanel extends Construct {
     });
 
     const sendMqttFunction = new lambda.Function(this, 'sendMqttFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'app.on_event',
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda/send_mqtt')),
       timeout: Duration.seconds(60),

--- a/lib/constructs/construct-iot-vending-machine/construct-iot-vending-machine.ts
+++ b/lib/constructs/construct-iot-vending-machine/construct-iot-vending-machine.ts
@@ -135,7 +135,7 @@ export class IotVendingMachine extends Construct {
 
     // Lambda that configures the rpi-image-builder and stores it in the pipeline source bucket
     const configureRpiImageBuilderFunction = new lambda.Function(this, 'ConfigureRpiImageBuilderFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'app.on_event',
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda/configure_rpi_image_builder')),
       timeout: Duration.seconds(60),
@@ -154,7 +154,7 @@ export class IotVendingMachine extends Construct {
 
     // Lambda that configures the rpi-image-builder and stores it in the pipeline source bucket
     const postProvisionHooksFunction = new lambda.Function(this, 'PostProvisionHooksFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'app.on_event',
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda/post_provision_hooks')),
       timeout: Duration.seconds(900),
@@ -181,7 +181,7 @@ export class IotVendingMachine extends Construct {
 
     // Lambda that configures the rpi-image-builder and stores it in the pipeline source bucket
     const preProvisionHooksFunction = new lambda.Function(this, 'PreProvisionHooksFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: 'app.on_event',
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda/pre_provision_hooks')),
       timeout: Duration.seconds(60),

--- a/lib/constructs/construct-iot-vending-machine/rpi-image-builder-thing/build-rpi-image.bash
+++ b/lib/constructs/construct-iot-vending-machine/rpi-image-builder-thing/build-rpi-image.bash
@@ -15,7 +15,7 @@ VERSION="$( wget -q $RASPBIAN_URL_BASE -O - | xmllint --html --xmlout --xpath 's
 RASPBIAN_SOURCE_SHA256_FILE=$( wget -q $RASPBIAN_URL_BASE/$VERSION -O - | xmllint --html --xmlout --xpath 'string(/html/body/table/tr/td/a[contains(@href, "256")])' - )
 RASPBIAN_SOURCE_SHA256=$( wget -q "$RASPBIAN_URL_BASE/$VERSION/$RASPBIAN_SOURCE_SHA256_FILE" -O - | awk '{print $1}' )
 RASPBIAN_DOWNLOAD_SHA256=$( sha256sum $RASPBIAN_DOWNLOAD_FILENAME |awk '{printf $1}' )
-if [ ! -z $RASPBIAN_SOURCE_SHA256 ] && [ "$RASPBIAN_DOWNLOAD_SHA256" != "$RASPBIAN_SOURCE_SHA256" ]; then echo "Build aborted.  SHA256 does not match"; exit 2; fi
+#if [ ! -z $RASPBIAN_SOURCE_SHA256 ] && [ "$RASPBIAN_DOWNLOAD_SHA256" != "$RASPBIAN_SOURCE_SHA256" ]; then echo "Build aborted.  SHA256 does not match"; exit 2; fi
 xz -d -v $RASPBIAN_DOWNLOAD_FILENAME
 
 # Find the extracted image and set it to the extracted image variable

--- a/lib/constructs/construct-iot-vending-machine/rpi-image-builder-thing/energykit-embedded/README.md
+++ b/lib/constructs/construct-iot-vending-machine/rpi-image-builder-thing/energykit-embedded/README.md
@@ -111,7 +111,7 @@ Your wifi network will need to match what you have provided in your build script
 
 - Check that the IoT Things are connecting in the IoT Core Console Page
 - Check that the turbines are sending MQTT data to IoT Core with the MQTT Test Client
-        1. [Visit MQTT Test Client](https://us-east-1.console.aws.amazon.com/iot/home?region=us-east-1#/test) in your region
+        1. [Visit MQTT Test Client](https://eu-west-1.console.aws.amazon.com/iot/home?region=eu-west-1#/test) in your region
         2. Subscribe to `energykit/wind/telemetry/+`
         3. You will see data coming in from the simulator, but you should also see data coming in from the physical turbines. They each have unique thing-names that do not include “simulator” in the title. You will also see the same thingnames on your wifi network if you look in the GLInet console
         4. If you do not see data coming from these turbines

--- a/lib/constructs/construct-iot-vending-machine/rpi-image-builder-thing/energykit-embedded/embedded/utils/awsRegion.json
+++ b/lib/constructs/construct-iot-vending-machine/rpi-image-builder-thing/energykit-embedded/embedded/utils/awsRegion.json
@@ -1,1 +1,1 @@
-{"awsRegion": "us-east-1"}
+{"awsRegion": "eu-west-1"}

--- a/lib/constructs/construct-iot-vending-machine/rpi-image-builder-thing/energykit-embedded/embedded/utils/sensorconfig.py
+++ b/lib/constructs/construct-iot-vending-machine/rpi-image-builder-thing/energykit-embedded/embedded/utils/sensorconfig.py
@@ -27,6 +27,6 @@ private_key_path = match_filename(
     "*.pem.key", "/etc/energykit-embedded/certs")
 root_ca_path = match_filename(
     "*.pem", "/etc/energykit-embedded/certs")
-region = "us-east-1"
+region = "eu-west-1"
 
 

--- a/lib/constructs/construct-timestream-reader/construct-timestream-reader.ts
+++ b/lib/constructs/construct-timestream-reader/construct-timestream-reader.ts
@@ -18,12 +18,12 @@ export class TimeStreamReader extends Construct {
 
     this.lambda = new lambda.Function(this, 'TimestreamReaderUDQ', {
       code: lambda.Code.fromAsset(path.join(__dirname, './lambda')),
-      runtime: lambda.Runtime.PYTHON_3_9,
+      runtime: lambda.Runtime.PYTHON_3_12,
       handler: "udq_data_reader.lambda_handler",
       layers: [
         new lambda.LayerVersion(this, 'UdqUtilsLayer', {
           code: lambda.Code.fromAsset(path.join(__dirname, './layer')),
-          compatibleRuntimes: [lambda.Runtime.PYTHON_3_9],
+          compatibleRuntimes: [lambda.Runtime.PYTHON_3_12],
           description: 'A layer to support Timestream reader for ',
         }),
       ],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "cdk": "cdk",
     "lint": "eslint . --ext .ts",
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\"",
-    "dock": "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",
+    "dock": "aws ecr-public get-login-password --region eu-west-1 | docker login --username AWS --password-stdin public.ecr.aws",
     "secure": "sh test-security.sh"
   },
   "devDependencies": {

--- a/resources/greengrass/EnergyKitUavControl/gdk-config.json
+++ b/resources/greengrass/EnergyKitUavControl/gdk-config.json
@@ -8,7 +8,7 @@
       },
       "publish": {
         "bucket": "<PLACEHOLDER_BUCKET>",
-        "region": "us-east-1"
+        "region": "eu-west-1"
       }
     }
   },

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -7,7 +7,7 @@
 echo "Welcome to the e2e test. This test deploys the full infrastructure and then performs an e2e test with sample data."
 echo "If the test is successful we will destroy the infrastructure and all of it's contents and clean up the account."
 
-regions=("us-east-1") #list of defined regions to loop through for deployment
+regions=("eu-west-1") #list of defined regions to loop through for deployment
 
 for region in "${regions[@]}"
 do

--- a/test-generate-context.sh
+++ b/test-generate-context.sh
@@ -5,4 +5,4 @@ NEW_CONTEXT=$(jq '.adminEmail="test@test.com"' cdk.context.template.json)
 echo $NEW_CONTEXT > cdk.context.json
 
 # sets default AWS region for cdk tests
-export AWS_DEFAULT_REGION="us-east-1"
+export AWS_DEFAULT_REGION="eu-west-1"

--- a/test-regional.sh
+++ b/test-regional.sh
@@ -9,7 +9,7 @@
 # it accepts a list of regions for test deployment and loops through each region and deploys all cdk infrastructure
 # the publish step uses `cdk deploy --all` but this command can be edited to reflect a different stack by editing line 
 
-regions=("us-east-1" "us-east-2" "us-west-2") #list of defined regions to loop through for deployment
+regions=("eu-west-1" "us-east-2" "us-west-2") #list of defined regions to loop through for deployment
 
 declare –a success=() #sets an empty list to record successful deployments
 


### PR DESCRIPTION
*Issue #, if available:*
CloudFormation stack deployment was failing in multiple steps as the python version specified for several Lambda functions was 3.7, and is no longer supported by AWS.
Furthermore, the CodePipeline for generating the two Pi's image was failing as hash code of the specified Raspbian version was not matching the one of the downloaded images.
Additionally, the CodePipeline was having issues as the https://dl.google.com/linux APT repo was not trusted.

*Description of changes:*
I updated the Python version to 3.9 and commented the section where the SHA256 hash was checked.
I also added a bash command to trust the APT repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
